### PR TITLE
fix: enable relative base asset paths for github.io subfolder

### DIFF
--- a/src/aecdump-viewer/vite.config.ts
+++ b/src/aecdump-viewer/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: './', // Enable relative asset paths for subfolder deployment on github.io
   server: {
     // Allow any host to respond to proxy requests (e.g. from cloud workspace / corporate proxy)
     allowedHosts: true,


### PR DESCRIPTION
- Configured base: './' in vite.config.ts to generate relative asset paths. This ensures all script bundles are resolved correctly when the static build is deployed under a subfolder on github.io (/audio-tests/aecdump-viewer/).