### PR TITLE
Close AudioContext when recording visualization stops

### DIFF
--- a/src/pwa-audio-recorder/app.mjs
+++ b/src/pwa-audio-recorder/app.mjs
@@ -234,7 +234,13 @@ function visualizeRecording({stream, outlineIndicator, waveformIndicator}) {
   /** Repeatedly draws the waveform and loudness indicator. */
   function draw() {
     if (!stream.active) {
-      return; // Stop drawing loop once the recording stopped.
+      // Stop drawing loop once the recording stopped, and release the
+      // AudioContext. Browsers limit the number of concurrent AudioContexts, so
+      // failing to close it here leaks one context per recording and, after a
+      // few dozen recordings, prevents new contexts from starting (the waveform
+      // stops appearing and playback breaks until the page is refreshed).
+      audioCtx.close();
+      return;
     }
 
     analyser.getByteFrequencyData(dataArray);


### PR DESCRIPTION
Each recording created a new AudioContext for the waveform AnalyserNode but never closed it. Browsers limit the number of concurrent AudioContexts, so after ~40 record/stop cycles new contexts fail to start: getByteFrequencyData() returns silence (the waveform stops appearing) and audio decode/playback breaks until the page is refreshed.

Close the AudioContext in the draw loop once the stream is no longer active, mirroring the cleanup already done in the download handler.

Bug: b/538354264